### PR TITLE
Split field values only on the last '?' to avoid a MatchError

### DIFF
--- a/lib/arc_ecto/definition.ex
+++ b/lib/arc_ecto/definition.ex
@@ -1,5 +1,5 @@
 defmodule Arc.Ecto.Definition do
-  defmacro __using__(options) do
+  defmacro __using__(_options) do
     definition = __CALLER__.module
 
     quote do

--- a/lib/arc_ecto/type.ex
+++ b/lib/arc_ecto/type.ex
@@ -8,13 +8,13 @@ defmodule Arc.Ecto.Type do
     end
   end
 
-  def load(definition, value) do
+  def load(_definition, value) do
     [_, file_name, gsec] = Regex.run(~r{^(.*)\?(\d+)$}, value)
     updated_at = Ecto.DateTime.from_erl(:calendar.gregorian_seconds_to_datetime(String.to_integer(gsec)))
     {:ok, %{file_name: file_name, updated_at: updated_at}}
   end
 
-  def dump(definition, %{file_name: file_name, updated_at: updated_at}) do
+  def dump(_definition, %{file_name: file_name, updated_at: updated_at}) do
     gsec = :calendar.datetime_to_gregorian_seconds(Ecto.DateTime.to_erl(updated_at))
     {:ok, "#{file_name}?#{gsec}"}
   end

--- a/lib/arc_ecto/type.ex
+++ b/lib/arc_ecto/type.ex
@@ -8,8 +8,6 @@ defmodule Arc.Ecto.Type do
     end
   end
 
-  def cast(definition, _other), do: :error
-
   def load(definition, value) do
     [_, file_name, gsec] = Regex.run(~r{^(.*)\?(\d+)$}, value)
     updated_at = Ecto.DateTime.from_erl(:calendar.gregorian_seconds_to_datetime(String.to_integer(gsec)))

--- a/lib/arc_ecto/type.ex
+++ b/lib/arc_ecto/type.ex
@@ -11,7 +11,7 @@ defmodule Arc.Ecto.Type do
   def cast(definition, _other), do: :error
 
   def load(definition, value) do
-    [file_name, gsec] = String.split(value, "?")
+    [_, file_name, gsec] = Regex.run(~r{^(.*)\?(\d+)$}, value)
     updated_at = Ecto.DateTime.from_erl(:calendar.gregorian_seconds_to_datetime(String.to_integer(gsec)))
     {:ok, %{file_name: file_name, updated_at: updated_at}}
   end

--- a/test/type_test.exs
+++ b/test/type_test.exs
@@ -18,4 +18,10 @@ defmodule ArcTest.Ecto.Type do
     {:ok, value} = DummyDefinition.Type.load("file.png?62167219200")
     assert value == %{file_name: "file.png", updated_at: timestamp}
   end
+
+  test "loads pathological filenames" do
+    timestamp = Ecto.DateTime.cast!({{1970, 1, 1}, {0, 0, 0}})
+    {:ok, value} = DummyDefinition.Type.load("image.php?img=file.png?62167219200")
+    assert value == %{file_name: "image.php?img=file.png", updated_at: timestamp}
+  end
 end

--- a/test/type_test.exs
+++ b/test/type_test.exs
@@ -1,0 +1,21 @@
+defmodule ArcTest.Ecto.Type do
+  use ExUnit.Case, async: false
+
+  defmodule DummyDefinition do
+    use Arc.Definition
+    use Arc.Ecto.Definition
+  end
+
+  test "dumps filenames with timestamp" do
+    timestamp = Ecto.DateTime.cast!({{1970, 1, 1}, {0, 0, 0}})
+    {:ok, value} =
+      DummyDefinition.Type.dump(%{file_name: "file.png", updated_at: timestamp})
+    assert value == "file.png?62167219200"
+  end
+
+  test "loads filenames with timestamp" do
+    timestamp = Ecto.DateTime.cast!({{1970, 1, 1}, {0, 0, 0}})
+    {:ok, value} = DummyDefinition.Type.load("file.png?62167219200")
+    assert value == %{file_name: "file.png", updated_at: timestamp}
+  end
+end


### PR DESCRIPTION
Fixes a MatchError in Arc.Ecto.Type.load/2 that happens when we store a filename with question marks in it. I've added a test that fails without the fix.