### PR TITLE
Drop nil params

### DIFF
--- a/lib/arc_ecto/schema.ex
+++ b/lib/arc_ecto/schema.ex
@@ -31,6 +31,7 @@ defmodule Arc.Ecto.Schema do
           params
           |> Arc.Ecto.Schema.convert_params_to_binary
           |> Dict.take(allowed)
+          |> Enum.reject(fn({field, file}) -> is_nil(file) end)
           |> Enum.map(fn({field, file}) -> {field, {file, scope}} end)
           |> Enum.into(%{})
       end


### PR DESCRIPTION
The problem existing if you have `cast_attachment(:something_that's_nil)` to changeset. This kind of problem:

``` elixir
** (FunctionClauseError) no function clause matching in Arc.Actions.Store.store/2
     stacktrace:
       (arc) lib/arc/actions/store.ex:8: Arc.Actions.Store.store(MyReelty.Video, {nil, %MyReelty.Review{comments_count: 0, zillow_status: nil, full_address: nil, country:
 "USA", price: #Decimal<175.3>, visits: #Ecto.Association.NotLoaded<association :visits is not loaded>, thumbnail_time: nil, __meta__: #Ecto.Schema.Metadata<:loaded, "rev
iews">, user: #Ecto.Association.NotLoaded<association :user is not loaded>, premium: #Ecto.Association.NotLoaded<association :premium is not loaded>, vimeo_url: nil, user
_id: 631, credits: nil, external_provider_url: nil, inserted_at: #Ecto.DateTime<2016-07-04 12:36:27>, video: %{file_name: "sample.mp4", updated_at: #Ecto.DateTime<2016-07
-04 12:36:27>}, likes: #Ecto.Association.NotLoaded<association :likes is not loaded>, location: nil, property_type: "some content", review_thumbnail: nil, deleted_at: nil
, visits_count: 0, comments: #Ecto.Association.NotLoaded<association :comments is not loaded>, likes_count: 0, city: "Las Vegas", beds: nil, zipcode: "1234", bookmarks: #
Ecto.Association.NotLoaded<association :bookmarks is not loaded>, id: 307, square: #Decimal<120.5>, state: "Nevada", updated_at: #Ecto.DateTime<2016-07-04 12:36:27>, avai
lability: true, zpid: nil, baths: 42, address: "11th avenue", description: "some content", thumbnail_type: "screenshot"}})
```