### PR TITLE
Fix ecto requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Arc.Ecto.Mixfile do
   defp deps do
     [
       {:arc,  "~> 0.5.3"},
-      {:ecto, "~> 2.0.0"},
+      {:ecto, "~> 2.0"},
       {:mock, "~> 0.1.1", only: :test}
     ]
   end


### PR DESCRIPTION
Since ecto follows semver we should use a more allowing requirement.

It also seems some users are getting ecto conflicts when using the latest released version of this package. A new release with the new ecto requirement would be appreciated.