### PR TITLE
Suggest adding arc_ecto to applications in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ defp deps do
     {:arc_ecto, "~> 0.4.3"}
   ]
 end
+
+defp application do
+  [applications: [:arc_ecto]]
+end
 ```
 
 Then run `mix deps.get` in your shell to fetch the dependencies.


### PR DESCRIPTION
I had a bug in a production app because I forgot to add arc_ecto to mix applications. I think adding this to the readme will help future users avoid this problem.