### PR TITLE
Fix compile warning

### DIFF
--- a/lib/arc_ecto/type.ex
+++ b/lib/arc_ecto/type.ex
@@ -4,7 +4,7 @@ defmodule Arc.Ecto.Type do
   @filename_with_timestamp ~r{^(.*)\?(\d+)$}
 
   # Support embeds_one/embeds_many
-  def cast(definition, %{"file_name" => file, "updated_at" => updated_at}) do
+  def cast(_definition, %{"file_name" => file, "updated_at" => updated_at}) do
     {:ok, %{file_name: file, updated_at: updated_at}}
   end
   def cast(definition, args) do


### PR DESCRIPTION
The variable `definition` is unused. Adding the `_` removes the following compile warning:

```
==> arc_ecto
Compiling 4 files (.ex)
warning: variable definition is unused
  lib/arc_ecto/type.ex:7
```