### PR TITLE
Update mix.exs for current arc version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Arc.Ecto.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:arc,  "~> 0.5.3"},
+      {:arc,  "~> 0.6.0-rc1"},
       {:ecto, "~> 2.0"},
       {:mock, "~> 0.1.1", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev}


### PR DESCRIPTION
When doing mix hex.build with current version, I get a hex versioning error:

> Failed to use "arc" because
>  arc_ecto (version 0.4.4) requires ~> 0.5.3
>  Locked to 0.6.0-rc1 in your mix.lock

`** (Mix) Hex dependency resolution failed, relax the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}`