### PR TITLE
Replace deprecated `Dict.take/2` with `Map.take/2`

### DIFF
--- a/lib/arc_ecto/schema.ex
+++ b/lib/arc_ecto/schema.ex
@@ -31,7 +31,7 @@ defmodule Arc.Ecto.Schema do
         %{} ->
           params
           |> Arc.Ecto.Schema.convert_params_to_binary
-          |> Dict.take(allowed)
+          |> Map.take(allowed)
           |> Enum.reduce([], fn
             # Don't wrap nil casts in the scope object
             {field, nil}, fields -> [{field, nil} | fields]


### PR DESCRIPTION
`Dict.take/2` is deprecated and in Elixir 1.4.0 it emits a warning on any
module that uses `Arc.Ecto.Schema`.

`Map.take/2` has been available since 1.0 so this should not cause any
backwards compatibility issues.