### PR TITLE
use parentheses to remove ambiguity in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,11 +7,11 @@ defmodule Arc.Ecto.Mixfile do
     [app: :arc_ecto,
      version: @version,
      elixir: "~> 1.0",
-     deps: deps,
+     deps: deps(),
 
     # Hex
-     description: description,
-     package: package]
+     description: description(),
+     package: package()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
with elixir 1.4 I got this warning

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /my_app/deps/arc_ecto/mix.exs:10

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /my_app/deps/arc_ecto/mix.exs:13

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /my_app/deps/arc_ecto/mix.exs:14
```
