### PR TITLE
Overriding delete function

### DIFF
--- a/lib/arc_ecto/definition.ex
+++ b/lib/arc_ecto/definition.ex
@@ -30,6 +30,10 @@ defmodule Arc.Ecto.Definition do
       end
 
       def url(f, v, options), do: super(f, v, options)
+      
+      def delete({%{file_name: file_name, updated_at: _updated_at}, scope}), do: super({file_name, scope})
+
+      def delete(args), do: super(args)
     end
   end
 end


### PR DESCRIPTION
Hi everybody :)

```
defmodule App.Photo do
  use App.Web, :model
  use Arc.Ecto.Schema

  schema "photos" do
    field :file, App.PhotoUploader.Type
  end
end

.....

photo = Repo.get!(Photo, 4)
PhotoUploader.delete({photo.file, photo}) # dont work
PhotoUploader.delete({photo.file.file_name, photo}) # work correctly
```

I suggest the first variant to deleting photo where first tuple value is struct of PhotoUploader.Type

P.S My suggestions demands changes in arc repository also:
https://github.com/stavro/arc/pull/182

