### PR TITLE
ensure that arc_ecto starts arc

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Arc.Ecto.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :arc]]
   end
 
   defp description do


### PR DESCRIPTION
For non-dev environments we want to ensure that arc_ecto starts arc. Else, the README should instruct the developer to either follow the instructions for installing arc or adding it to the consuming app's `applications`