### PR TITLE
Support casting from string in embed

### DIFF
--- a/lib/arc_ecto/type.ex
+++ b/lib/arc_ecto/type.ex
@@ -7,6 +7,9 @@ defmodule Arc.Ecto.Type do
   def cast(_definition, %{"file_name" => file, "updated_at" => updated_at}) do
     {:ok, %{file_name: file, updated_at: updated_at}}
   end
+  def cast(definition, value) when is_bitstring(value) do
+    load(definition, value)
+  end
   def cast(definition, args) do
     case definition.store(args) do
       {:ok, file} -> {:ok, %{file_name: file, updated_at: Ecto.DateTime.utc}}

--- a/test/type_test.exs
+++ b/test/type_test.exs
@@ -42,4 +42,10 @@ defmodule ArcTest.Ecto.Type do
     {:ok, dumped_type} = DummyDefinition.Type.dump(value)
     assert dumped_type == "file.png"
   end
+
+  test "casts embed value" do
+    {:ok, value} = DummyDefinition.Type.cast("file.png?62167219200")
+    assert value.file_name == "file.png"
+    assert value.updated_at == Ecto.DateTime.cast!({{1970, 1, 1}, {0, 0, 0}})
+  end
 end


### PR DESCRIPTION
I use PostgresSQL's `JSON_AGG` function which serializes rows from a joined table into single JSON field and then use Ecto's `embeds_many` to inflate them into structs. These structs have Arc type field. When Ecto [calls cast/2](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/adapters/sql.ex#L354) with a string of the form `file_name?updated_at` as the second argument. It matches the last definition which tries to store this string and fails but I expect it to do the same things as `load/2` does in this case. So here is my patch for it.