### PR TITLE
Add delete_attachments to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,32 @@ Both public and signed urls will include the timestamp for cache busting, and ar
   MyApp.Avatar.url({user.avatar, user}, :thumb, signed: true)
 ```
 
+### Delete attached file from storage
+
+Attachments can be deleted using `delete_attachments/2` before calling `Repo.delete/1`.
+
+```elixir
+defmodule MyApp.User do
+  # ...
+
+  def delete_changeset(data) do
+    data
+    |> changeset(%{})
+    |> delete_attachments(@attachments)
+  end
+end
+```
+
+Then, to delete, instead of calling `Repo.delete` from element, do it from deletion
+changeset (like when using `Ecto.Changeset.prepare_changes/2`):
+
+```elixir
+  user
+  |> MyApp.User.delete_changeset()
+  |> MyApp.Repo.delete()
+
+```
+
 ## License
 
 Copyright 2015 Sean Stavropoulos

--- a/lib/arc_ecto/definition.ex
+++ b/lib/arc_ecto/definition.ex
@@ -6,6 +6,7 @@ defmodule Arc.Ecto.Definition do
       defmodule Module.concat(unquote(definition), "Type") do
         @behaviour Ecto.Type
         def type, do: Arc.Ecto.Type.type
+        def definition, do: unquote(definition)
         def cast(value), do: Arc.Ecto.Type.cast(unquote(definition), value)
         def load(value), do: Arc.Ecto.Type.load(unquote(definition), value)
         def dump(value), do: Arc.Ecto.Type.dump(unquote(definition), value)
@@ -30,7 +31,7 @@ defmodule Arc.Ecto.Definition do
       end
 
       def url(f, v, options), do: super(f, v, options)
-      
+
       def delete({%{file_name: file_name, updated_at: _updated_at}, scope}), do: super({file_name, scope})
 
       def delete(args), do: super(args)

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule Arc.Ecto.Mixfile do
     [app: :arc_ecto,
      version: @version,
      elixir: "~> 1.0",
+     elixirc_paths: elixirc_paths(Mix.env),
      deps: deps(),
 
     # Hex
@@ -21,6 +22,10 @@ defmodule Arc.Ecto.Mixfile do
     [applications: [:logger, :arc]]
   end
 
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
+  
   defp description do
     """
     An integration with Arc and Ecto.

--- a/test/support/dummy_definition.ex
+++ b/test/support/dummy_definition.ex
@@ -1,0 +1,4 @@
+defmodule ArcTest.Ecto.DummyDefinition do
+  use Arc.Definition
+  use Arc.Ecto.Definition
+end


### PR DESCRIPTION
Added `delete_attachments` to easily delete file contents when deleting schema data using changesets. Readme file has been updated with an example.

Some changes have been made to tests because of some problems with mocks. I was trying not to change them too much. But here are (commented in commit): DummyDefinition being in the same file than schema test caused mock library to fail in some cases (as it documentation says, because of the way mock overrides the module, it must be defined in a separate file from the test file). That's why definition module was declared in setup for each test, causing some warnings that are gone now.

Just tell me if you need something more. Thanks for the library!