### PR TITLE
Update Type to expose errors through the logs

### DIFF
--- a/lib/arc_ecto/type.ex
+++ b/lib/arc_ecto/type.ex
@@ -10,7 +10,10 @@ defmodule Arc.Ecto.Type do
   def cast(definition, args) do
     case definition.store(args) do
       {:ok, file} -> {:ok, %{file_name: file, updated_at: Ecto.DateTime.utc}}
-      _ -> :error
+      error -> 
+      require Logger
+      Logger.error(inspect(error))
+      :error
     end
   end
 


### PR DESCRIPTION
I encountered an issue where my version of image magick wasn't up to date and this cast function was swallowing the error message, making it extremely hard to debug. I eventually ended up editing the deps directly to find out all I needed to do was update imagemagick. The change above will expose the error in the logs at least.