### PR TITLE
allow passing binary data structs as attachments

### DIFF
--- a/lib/arc_ecto/schema.ex
+++ b/lib/arc_ecto/schema.ex
@@ -36,6 +36,11 @@ defmodule Arc.Ecto.Schema do
             # Allow casting Plug.Uploads
             {field, upload = %{__struct__: Plug.Upload}}, fields -> [{field, {upload, scope}} | fields]
 
+            # Allow casting binary data structs
+            {field, upload = %{filename: filename, binary: binary}}, fields
+              when is_binary(filename) and is_binary(binary) ->
+              [{field, {upload, scope}} | fields]
+
             # If casting a binary (path), ensure we've explicitly allowed paths
             {field, path}, fields when is_binary(path) ->
               cond do

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -113,4 +113,9 @@ defmodule ArcTest.Ecto.Schema do
     changeset = TestUser.url_changeset(%TestUser{}, %{"avatar" => "/path/to/my/file.png"})
     assert not called DummyDefinition.store({"/path/to/my/file.png", %TestUser{}})
   end
+
+  test_with_mock "casting binary data struct attachments", DummyDefinition, [store: fn({%{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}, %TestUser{}}) -> {:ok, "file.png"} end] do
+    changeset = TestUser.changeset(%TestUser{}, %{"avatar" => %{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}})
+    assert called DummyDefinition.store({%{filename: "/path/to/my/file.png", binary: <<1, 2, 3>>}, %TestUser{}})
+  end
 end


### PR DESCRIPTION
arc allows storing `%{filename: filename, binary: data}`,
and now arc_ecto allows these structs to be accepted in
`cast_attachments`

fixes #54