### PR TITLE
fix 'filename' spelling in all tests

### DIFF
--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -48,7 +48,7 @@ defmodule ArcTest.Ecto.Schema do
   end
 
   def build_upload(path) do
-    %{__struct__: Plug.Upload, path: path, file_name: Path.basename(path)}
+    %{__struct__: Plug.Upload, path: path, filename: Path.basename(path)}
   end
 
   test "supports :invalid changeset" do
@@ -58,14 +58,14 @@ defmodule ArcTest.Ecto.Schema do
     assert cs.errors   == [avatar: {"can't be blank", []}]
   end
 
-  test_with_mock "cascades storage success into a valid change", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", file_name: "file.png"}, %TestUser{}}) -> {:ok, "file.png"} end] do
+  test_with_mock "cascades storage success into a valid change", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:ok, "file.png"} end] do
     upload = build_upload("/path/to/my/file.png")
     cs = TestUser.changeset(%TestUser{}, %{"avatar" => upload})
     assert cs.valid?
     %{file_name: "file.png", updated_at: _} = cs.changes.avatar
   end
 
-  test_with_mock "cascades storage error into an error", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", file_name: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
+  test_with_mock "cascades storage error into an error", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
     upload = build_upload("/path/to/my/file.png")
     cs = TestUser.changeset(%TestUser{}, %{"avatar" => upload})
     assert called DummyDefinition.store({upload, %TestUser{}})
@@ -73,25 +73,25 @@ defmodule ArcTest.Ecto.Schema do
     assert cs.errors == [avatar: {"is invalid", [type: ArcTest.Ecto.Schema.DummyDefinition.Type]}]
   end
 
-  test_with_mock "converts changeset into schema", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", file_name: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
+  test_with_mock "converts changeset into schema", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
     upload = build_upload("/path/to/my/file.png")
     TestUser.changeset(%TestUser{}, %{"avatar" => upload})
     assert called DummyDefinition.store({upload, %TestUser{}})
   end
 
-  test_with_mock "applies changes to schema", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", file_name: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
+  test_with_mock "applies changes to schema", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
     upload = build_upload("/path/to/my/file.png")
     TestUser.changeset(%TestUser{}, %{"avatar" => upload, "first_name" => "test"})
     assert called DummyDefinition.store({upload, %TestUser{first_name: "test"}})
   end
 
-  test_with_mock "converts atom keys", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", file_name: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
+  test_with_mock "converts atom keys", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
     upload = build_upload("/path/to/my/file.png")
     TestUser.changeset(%TestUser{}, %{avatar: upload})
     assert called DummyDefinition.store({upload, %TestUser{}})
   end
 
-  test_with_mock "casting nil attachments", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", file_name: "file.png"}, %TestUser{}}) -> {:ok, "file.png"} end] do
+  test_with_mock "casting nil attachments", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:ok, "file.png"} end] do
     changeset = TestUser.changeset(%TestUser{}, %{"avatar" => build_upload("/path/to/my/file.png")})
     changeset = TestUser.changeset2(changeset, %{"avatar" => nil})
     assert nil == Ecto.Changeset.get_field(changeset, :avatar)


### PR DESCRIPTION
Plug.Upload struct has a `filename` field, not `file_name`

Noticed it while working on #87: `arc` docs says `store/1` accepts `Plug.Upload` or map with `filename` field, but in tests `file_name` is used.