### PR TITLE
fixes #89: add the allow_urls feature

### DIFF
--- a/lib/arc_ecto/schema.ex
+++ b/lib/arc_ecto/schema.ex
@@ -41,10 +41,10 @@ defmodule Arc.Ecto.Schema do
 
             # If casting a binary (path), ensure we've explicitly allowed paths
             {field, path}, fields when is_binary(path) ->
-              if Keyword.get(options, :allow_paths, false) do
-                [{field, {path, scope}} | fields]
-              else
-                fields
+              cond do
+                Keyword.get(options, :allow_urls, false) and Regex.match?( ~r/^https?:\/\// , path) -> [{field, {path, scope}} | fields]
+                Keyword.get(options, :allow_paths, false) -> [{field, {path, scope}} | fields]
+                true -> fields
               end
           end)
           |> Enum.into(%{})

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -31,6 +31,13 @@ defmodule ArcTest.Ecto.Schema do
       |> validate_required(:avatar)
     end
 
+    def url_changeset(user, params \\ :invalid) do
+      user
+      |> cast(params, ~w(first_name)a)
+      |> cast_attachments(params, ~w(avatar)a, allow_urls: true)
+      |> validate_required(:avatar)
+    end
+
     def changeset2(user, params \\ :invalid) do
       user
       |> cast(params, ~w(first_name)a)
@@ -100,5 +107,15 @@ defmodule ArcTest.Ecto.Schema do
   test_with_mock "allow_paths => true", DummyDefinition, [store: fn({"/path/to/my/file.png", %TestUser{}}) -> {:ok, "file.png"} end] do
     changeset = TestUser.path_changeset(%TestUser{}, %{"avatar" => "/path/to/my/file.png"})
     assert called DummyDefinition.store({"/path/to/my/file.png", %TestUser{}})
+  end
+
+  test_with_mock "allow_urls => true", DummyDefinition, [store: fn({"http://external.url/file.png", %TestUser{}}) -> {:ok, "file.png"} end] do
+    changeset = TestUser.url_changeset(%TestUser{}, %{"avatar" => "http://external.url/file.png"})
+    assert called DummyDefinition.store({"http://external.url/file.png", %TestUser{}})
+  end
+
+  test_with_mock "allow_urls => true with an invalid URL", DummyDefinition, [store: fn({"/path/to/my/file.png", %TestUser{}}) -> {:ok, "file.png"} end] do
+    changeset = TestUser.url_changeset(%TestUser{}, %{"avatar" => "/path/to/my/file.png"})
+    assert not called DummyDefinition.store({"/path/to/my/file.png", %TestUser{}})
   end
 end


### PR DESCRIPTION
Thi pull request will add the `allow_urls` flag feature as an alternative to the `allow_paths` for all that users that want to prevent to use this library to upload local files but want to upload valid and external URLs.