### PR TITLE
Fix Ecto 3.0 warnings

### DIFF
--- a/lib/arc_ecto/schema.ex
+++ b/lib/arc_ecto/schema.ex
@@ -18,7 +18,7 @@ defmodule Arc.Ecto.Schema do
       end
 
       # Cast supports both atom and string keys, ensure we're matching on both.
-      allowed = Enum.map(allowed, fn key ->
+      allowed_param_keys = Enum.map(allowed, fn key ->
         case key do
           key when is_binary(key) -> key
           key when is_atom(key) -> Atom.to_string(key)
@@ -31,7 +31,7 @@ defmodule Arc.Ecto.Schema do
         %{} ->
           params
           |> Arc.Ecto.Schema.convert_params_to_binary
-          |> Map.take(allowed)
+          |> Map.take(allowed_param_keys)
           |> Enum.reduce([], fn
             # Don't wrap nil casts in the scope object
             {field, nil}, fields -> [{field, nil} | fields]

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Arc.Ecto.Mixfile do
   defp deps do
     [
       {:arc,  "~> 0.11.0"},
-      {:ecto, "~> 2.1"},
+      {:ecto, "~> 2.1 or ~> 3.0"},
       {:mock, "~> 0.1.1", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -1,6 +1,7 @@
 defmodule ArcTest.Ecto.Schema do
   use ExUnit.Case, async: false
   import Mock
+  import ExUnit.CaptureLog
 
   defmodule TestUser do
     use Ecto.Schema
@@ -53,28 +54,36 @@ defmodule ArcTest.Ecto.Schema do
 
   test_with_mock "cascades storage error into an error", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
     upload = build_upload("/path/to/my/file.png")
-    cs = TestUser.changeset(%TestUser{}, %{"avatar" => upload})
-    assert called DummyDefinition.store({upload, %TestUser{}})
-    assert cs.valid? == false
-    assert cs.errors == [avatar: {"is invalid", [type: DummyDefinition.Type, validation: :cast]}]
+    capture_log(fn ->
+      cs = TestUser.changeset(%TestUser{}, %{"avatar" => upload})
+      assert called DummyDefinition.store({upload, %TestUser{}})
+      assert cs.valid? == false
+      assert cs.errors == [avatar: {"is invalid", [type: DummyDefinition.Type, validation: :cast]}]
+    end)
   end
 
   test_with_mock "converts changeset into schema", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
     upload = build_upload("/path/to/my/file.png")
-    TestUser.changeset(%TestUser{}, %{"avatar" => upload})
-    assert called DummyDefinition.store({upload, %TestUser{}})
+    capture_log(fn ->
+      TestUser.changeset(%TestUser{}, %{"avatar" => upload})
+      assert called DummyDefinition.store({upload, %TestUser{}})
+    end)
   end
 
   test_with_mock "applies changes to schema", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
     upload = build_upload("/path/to/my/file.png")
-    TestUser.changeset(%TestUser{}, %{"avatar" => upload, "first_name" => "test"})
-    assert called DummyDefinition.store({upload, %TestUser{first_name: "test"}})
+    capture_log(fn ->
+      TestUser.changeset(%TestUser{}, %{"avatar" => upload, "first_name" => "test"})
+      assert called DummyDefinition.store({upload, %TestUser{first_name: "test"}})
+    end)
   end
 
   test_with_mock "converts atom keys", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:error, :invalid_file} end] do
     upload = build_upload("/path/to/my/file.png")
-    TestUser.changeset(%TestUser{}, %{avatar: upload})
-    assert called DummyDefinition.store({upload, %TestUser{}})
+    capture_log(fn ->
+      TestUser.changeset(%TestUser{}, %{avatar: upload})
+      assert called DummyDefinition.store({upload, %TestUser{}})
+    end)
   end
 
   test_with_mock "casting nil attachments", DummyDefinition, [store: fn({%{__struct__: Plug.Upload, path: "/path/to/my/file.png", filename: "file.png"}, %TestUser{}}) -> {:ok, "file.png"} end] do
@@ -84,7 +93,7 @@ defmodule ArcTest.Ecto.Schema do
   end
 
   test_with_mock "allow_paths => true", DummyDefinition, [store: fn({"/path/to/my/file.png", %TestUser{}}) -> {:ok, "file.png"} end] do
-    changeset = TestUser.path_changeset(%TestUser{}, %{"avatar" => "/path/to/my/file.png"})
+    _changeset = TestUser.path_changeset(%TestUser{}, %{"avatar" => "/path/to/my/file.png"})
     assert called DummyDefinition.store({"/path/to/my/file.png", %TestUser{}})
   end
 end


### PR DESCRIPTION
Fixes #102. Related #98 #99 #101. Same work is done in #101 and #99, except this PR doesn't bump the ecto requirement or use the formatter.

I didn't find it necessary to update the project's Ecto requirement. This should continue to work fine with Ecto 2.x, as well as silence the errors emitted with Ecto 3.x. I've tested this locally.

Sidenotes:
- Also suppressed logs when running tests. I'd be happy to assert the log output if that's the intention. Otherwise it was only polluting the stdout when running tests.