### PR TITLE
Handle nil urls for skipped versions

### DIFF
--- a/lib/arc_ecto/definition.ex
+++ b/lib/arc_ecto/definition.ex
@@ -17,11 +17,13 @@ defmodule Arc.Ecto.Definition do
         if options[:signed] do
           url
         else
-          case updated_at do
-            %NaiveDateTime{} ->
+          case {url, updated_at} do
+            {nil, _} -> nil
+
+            {_, %NaiveDateTime{}} ->
               version_url(updated_at, url)
 
-            string when is_bitstring(updated_at) ->
+            {_, string} when is_bitstring(updated_at) ->
               version_url(NaiveDateTime.from_iso8601!(string), url)
 
             _ ->
@@ -31,7 +33,7 @@ defmodule Arc.Ecto.Definition do
       end
 
       def url(f, v, options), do: super(f, v, options)
-      
+
       def delete({%{file_name: file_name, updated_at: _updated_at}, scope}), do: super({file_name, scope})
 
       def delete(args), do: super(args)

--- a/test/definition_test.exs
+++ b/test/definition_test.exs
@@ -25,4 +25,10 @@ defmodule ArcTest.Ecto.Definition do
     url = DummyDefinitionTwo.url({%{file_name: "test.png", updated_at: nil}, :scope}, :original, [])
     assert url == "fallback"
   end
+
+  test "url is nil if version is skipped" do
+    updated_at = NaiveDateTime.from_erl!({{2015, 1, 1}, {1, 1, 1}})
+    url = DummyDefinitionTwo.url({%{file_name: "test.png", updated_at: updated_at}, :scope}, :skipped, [])
+    assert is_nil(url)
+  end
 end

--- a/test/support/dummy_definition_two.ex
+++ b/test/support/dummy_definition_two.ex
@@ -1,4 +1,5 @@
 defmodule DummyDefinitionTwo do
+  def url(_, :skipped, _), do: nil
   def url(_, :original, _), do: "fallback"
   def url(_, :signed, _), do: "fallback?a=1&b=2"
   def store({file, _}), do: {:ok, file}


### PR DESCRIPTION
I added a PR to Arc last year that allows [skipping versions](https://github.com/stavro/arc/pull/247) (for example, an attachment uploader that only generates `:thumb` versions for files that support it).

I just realized I never submitted this PR to deal with the nil urls that Arc now returns for these skipped versions (before this PR, there would be an error trying to `URI.parse(url)` on `nil`).

