### PR TITLE
Check for the new using block in Ecto 3.2

### DIFF
--- a/lib/arc_ecto/definition.ex
+++ b/lib/arc_ecto/definition.ex
@@ -4,8 +4,13 @@ defmodule Arc.Ecto.Definition do
 
     quote do
       defmodule Module.concat(unquote(definition), "Type") do
-        @behaviour Ecto.Type
-        def type, do: Arc.Ecto.Type.type
+        if macro_exported?(Ecto.Type, :__using__, 1) do
+          use Ecto.Type
+        else
+          @behaviour Ecto.Type
+        end
+
+        def type, do: Arc.Ecto.Type.type()
         def cast(value), do: Arc.Ecto.Type.cast(unquote(definition), value)
         def load(value), do: Arc.Ecto.Type.load(unquote(definition), value)
         def dump(value), do: Arc.Ecto.Type.dump(unquote(definition), value)
@@ -31,13 +36,15 @@ defmodule Arc.Ecto.Definition do
       end
 
       def url(f, v, options), do: super(f, v, options)
-      
-      def delete({%{file_name: file_name, updated_at: _updated_at}, scope}), do: super({file_name, scope})
+
+      def delete({%{file_name: file_name, updated_at: _updated_at}, scope}),
+        do: super({file_name, scope})
 
       def delete(args), do: super(args)
 
       defp version_url(updated_at, url) do
         stamp = :calendar.datetime_to_gregorian_seconds(NaiveDateTime.to_erl(updated_at))
+
         case URI.parse(url).query do
           nil -> url <> "?v=#{stamp}"
           _ -> url <> "&v=#{stamp}"


### PR DESCRIPTION
Closes #119

https://github.com/elixir-ecto/ecto/blob/d8ae5564a17f5b0a40962d81ef71360560210f12/lib/ecto/type.ex#L83
https://github.com/elixir-ecto/ecto/blob/v3.2.0/CHANGELOG.md

From the Ecto changelog:
```
[Ecto.Type] Add a new embed_as/1 callback to Ecto.Type that allows adapters to control embedding behaviour
[Ecto.Type] Add use Ecto.Type for convenience that implements the new required callbacks
```

Ecto added a new `__using__` block for `Ecto.Type` which implements the behaviour + the new required functions.

This PR checks if `Ecto.Type` can be used, and otherwise just implements the `@behaviour`, to maintain compatibility with Ecto `< 3.2.0`.