### PR TITLE
Add default embed_as/1 and equals?/2 for ecto 3.2

### DIFF
--- a/lib/arc_ecto/definition.ex
+++ b/lib/arc_ecto/definition.ex
@@ -9,6 +9,8 @@ defmodule Arc.Ecto.Definition do
         def cast(value), do: Arc.Ecto.Type.cast(unquote(definition), value)
         def load(value), do: Arc.Ecto.Type.load(unquote(definition), value)
         def dump(value), do: Arc.Ecto.Type.dump(unquote(definition), value)
+        def embed_as(_format), do: :self
+        def equal?(term1, term2), do: term1 == term2
       end
 
       def url({%{file_name: file_name, updated_at: updated_at}, scope}, version, options) do


### PR DESCRIPTION
Ecto.Type version 3.2 requires a default implementation of embed_as/1 and equals?/2