### PR TITLE
Generate typespec with with Arc.Ecto.Definition

### DIFF
--- a/lib/arc_ecto/definition.ex
+++ b/lib/arc_ecto/definition.ex
@@ -10,6 +10,8 @@ defmodule Arc.Ecto.Definition do
           @behaviour Ecto.Type
         end
 
+        @type t() :: Arc.Ecto.t()
+
         def type, do: Arc.Ecto.Type.type()
         def cast(value), do: Arc.Ecto.Type.cast(unquote(definition), value)
         def load(value), do: Arc.Ecto.Type.load(unquote(definition), value)


### PR DESCRIPTION
This adds a `t()` typespec definition to the `__using__` macro in Arc.Ecto.Defintion, so that users can generate complete typespecs for their ecto schemas that include an arc definition.